### PR TITLE
feat: Add CreateMigrationCommand and improve test coverage

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         }
     ],
     "require": {
-        "php": "~8.1.0 || ~8.2.0 || ~8.3.0",
+        "php": "~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0",
         "composer/package-versions-deprecated": "^1.10.99",
         "cycle/annotated": "^3.3",
         "cycle/database": "^2.5",
@@ -20,7 +20,8 @@
         "cycle/orm": "^2.3",
         "cycle/schema-migrations-generator": "^2.1",
         "symfony/cache": "^5.4 || ^6.3 || ^7.0",
-        "symfony/console": "^6.3 || ^7.0"
+        "symfony/console": "^6.3 || ^7.0",
+        "symfony/filesystem": "^6.3 || ^7.2"
     },
     "require-dev": {
         "codeception/codeception": "^5.0",
@@ -31,8 +32,7 @@
         "phpstan/extension-installer": "^1.3",
         "phpstan/phpstan": "^1.10",
         "phpstan/phpstan-mockery": "^1.1",
-        "roave/security-advisories": "dev-master",
-        "symfony/filesystem": "^5.4 || ^6.3"
+        "roave/security-advisories": "dev-master"
     },
     "autoload": {
         "psr-4": {
@@ -65,8 +65,8 @@
             "@phpstan",
             "@test"
         ],
-        "cs-check": "php tools/php-cs-fixer/vendor/bin/php-cs-fixer fix -vvv --dry-run --diff",
-        "cs-fix": "php tools/php-cs-fixer/vendor/bin/php-cs-fixer fix -vvv",
+        "cs-check": "export PHP_CS_FIXER_IGNORE_ENV=1 && php tools/php-cs-fixer/vendor/bin/php-cs-fixer fix -vvv --dry-run --diff",
+        "cs-fix": "export PHP_CS_FIXER_IGNORE_ENV=1 && php tools/php-cs-fixer/vendor/bin/php-cs-fixer fix -vvv",
         "phpstan": "php vendor/bin/phpstan analyse",
         "test": "codecept run"
     }

--- a/src/Command/Migrator/CreateMigrationCommand.php
+++ b/src/Command/Migrator/CreateMigrationCommand.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sirix\Cycle\Command\Migrator;
+
+use const DIRECTORY_SEPARATOR;
+
+use DateTime;
+use Exception;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Filesystem\Filesystem;
+
+use function bin2hex;
+use function md5;
+use function microtime;
+use function preg_match;
+use function random_bytes;
+use function sprintf;
+use function ucfirst;
+
+class CreateMigrationCommand extends Command
+{
+    public function __construct(private readonly string $migrationDirectory, ?string $name = null)
+    {
+        parent::__construct($name);
+    }
+
+    protected function configure(): void
+    {
+        $this->setName('migrator:create-migration')
+            ->setDescription('Create an empty migration file')
+            ->addArgument('migrationName', InputArgument::REQUIRED, 'The name of the migration in PascalCase format')
+        ;
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $migrationName = $input->getArgument('migrationName');
+
+        if (! preg_match('/^[A-Z][A-Za-z0-9]+$/', $migrationName)) {
+            $output->writeln('<error>Invalid migration name. Use PascalCase format.</error>');
+
+            return Command::FAILURE;
+        }
+
+        $filename = $this->generateMigrationName($migrationName);
+
+        $filePath = $this->migrationDirectory . DIRECTORY_SEPARATOR . $filename;
+
+        $className = sprintf('Orm%s', ucfirst($this->getUniqueId()));
+        $fileContent = $this->getMigrationFileContent($className);
+
+        $filesystem = new Filesystem();
+
+        try {
+            $filesystem->dumpFile($filePath, $fileContent);
+            $output->writeln("<info>Migration created: {$filePath}</info>");
+        } catch (Exception $e) {
+            $output->writeln("<error>Failed to create migration: {$e->getMessage()}</error>");
+
+            return Command::FAILURE;
+        }
+
+        return Command::SUCCESS;
+    }
+
+    private function getMigrationFileContent(string $className): string
+    {
+        return <<<PHP
+        <?php
+
+        declare(strict_types=1);
+
+        namespace Migration;
+
+        use Cycle\\Migrations\\Migration;
+
+        class {$className} extends Migration
+        {
+            protected const string DATABASE = 'main-db';
+
+            public function up(): void
+            {
+            }
+
+            public function down(): void
+            {
+            }
+        }
+        PHP;
+    }
+
+    private function generateMigrationName(string $migrationName): string
+    {
+        $timestamp = (new DateTime())->format('Ymd.His');
+
+        return sprintf('%s_0_0_%s.php', $timestamp, $migrationName);
+    }
+
+    private function getUniqueId(): string
+    {
+        try {
+            return bin2hex(random_bytes(18));
+        } catch (Exception) {
+            return bin2hex(md5(microtime()));
+        }
+    }
+}

--- a/src/Command/Migrator/CreateMigrationCommandFactory.php
+++ b/src/Command/Migrator/CreateMigrationCommandFactory.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sirix\Cycle\Command\Migrator;
+
+use Cycle\Database\Exception\ConfigException;
+use Psr\Container\ContainerExceptionInterface;
+use Psr\Container\ContainerInterface;
+use Psr\Container\NotFoundExceptionInterface;
+
+class CreateMigrationCommandFactory
+{
+    /**
+     * @throws ContainerExceptionInterface
+     * @throws NotFoundExceptionInterface
+     */
+    public function __invoke(ContainerInterface $container): CreateMigrationCommand
+    {
+        $config = $container->has('config')
+            ? $container->get('config')
+            : [];
+
+        if (! isset($config['migrator']['directory'])) {
+            throw new ConfigException('Expected config migrator');
+        }
+
+        $migrationDirectory = $config['migrator']['directory'];
+
+        return new CreateMigrationCommand($migrationDirectory);
+    }
+}

--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -35,6 +35,7 @@ class ConfigProvider
                 Service\MigratorService::class => Service\MigratorServiceFactory::class,
                 Command\Migrator\MigrateCommand::class => Command\Migrator\MigrateCommandFactory::class,
                 Command\Migrator\RollbackCommand::class => Command\Migrator\RollbackCommandFactory::class,
+                Command\Migrator\CreateMigrationCommand::class => Command\Migrator\CreateMigrationCommandFactory::class,
             ],
         ];
     }
@@ -48,6 +49,7 @@ class ConfigProvider
             'commands' => [
                 'migrator:migrate' => Command\Migrator\MigrateCommand::class,
                 'migrator:rollback' => Command\Migrator\RollbackCommand::class,
+                'migrator:create-migration' => Command\Migrator\CreateMigrationCommand::class,
             ],
         ];
     }

--- a/tests/Unit/Command/CreateMigrationCommandTest.php
+++ b/tests/Unit/Command/CreateMigrationCommandTest.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sirix\Cycle\Test\Unit\Command;
+
+use const DIRECTORY_SEPARATOR;
+
+use PHPUnit\Framework\TestCase;
+use Sirix\Cycle\Command\Migrator\CreateMigrationCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Exception\ExceptionInterface;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\BufferedOutput;
+use Symfony\Component\Filesystem\Filesystem;
+
+use function basename;
+use function file_get_contents;
+use function glob;
+use function mkdir;
+use function sys_get_temp_dir;
+use function uniqid;
+
+/**
+ * @internal
+ *
+ * @covers \Sirix\Cycle\Command\Migrator\CreateMigrationCommand
+ */
+class CreateMigrationCommandTest extends TestCase
+{
+    private string $migrationDirectory;
+
+    protected function setUp(): void
+    {
+        $this->migrationDirectory = sys_get_temp_dir() . DIRECTORY_SEPARATOR . uniqid('migrations_', true);
+        mkdir($this->migrationDirectory, 0777, true);
+    }
+
+    protected function tearDown(): void
+    {
+        $filesystem = new Filesystem();
+        $filesystem->remove($this->migrationDirectory);
+    }
+
+    /**
+     * @throws ExceptionInterface
+     */
+    public function testExecuteWithValidMigrationName(): void
+    {
+        $command = new CreateMigrationCommand($this->migrationDirectory);
+
+        $input = new ArrayInput(['migrationName' => 'ValidMigrationName']);
+        $output = new BufferedOutput();
+
+        $resultCode = $command->run($input, $output);
+
+        $outputContent = $output->fetch();
+        $this->assertSame(0, $resultCode);
+        $this->assertStringContainsString('Migration created:', $outputContent);
+
+        $migrations = (array) glob($this->migrationDirectory . DIRECTORY_SEPARATOR . '*.php');
+        $this->assertCount(1, $migrations);
+
+        $migrationFileName = basename((string) $migrations[0]);
+        $this->assertMatchesRegularExpression('/^\d{8}\.\d{6}_0_0_ValidMigrationName\.php$/', $migrationFileName);
+
+        $fileContent = file_get_contents((string) $migrations[0]);
+        $this->assertStringContainsString('namespace Migration;', (string) $fileContent);
+        $this->assertStringContainsString('class Orm', (string) $fileContent);
+    }
+
+    /**
+     * @throws ExceptionInterface
+     */
+    public function testExecuteWithInvalidMigrationName(): void
+    {
+        $command = new CreateMigrationCommand($this->migrationDirectory);
+
+        $input = new ArrayInput(['migrationName' => 'invalid_migration_name']);
+        $output = new BufferedOutput();
+
+        $resultCode = $command->run($input, $output);
+
+        $outputContent = $output->fetch();
+
+        $this->assertSame(1, $resultCode);
+        $this->assertStringContainsString('Invalid migration name. Use PascalCase format.', $outputContent);
+    }
+
+    /**
+     * @throws ExceptionInterface
+     */
+    public function testExecuteHandlesFilesystemException(): void
+    {
+        $command = new CreateMigrationCommand('/dev/null');
+
+        $input = new ArrayInput(['migrationName' => 'ValidMigrationName']);
+        $output = new BufferedOutput();
+
+        $resultCode = $command->run($input, $output);
+
+        $outputContent = $output->fetch();
+
+        $this->assertSame(Command::FAILURE, $resultCode);
+        $this->assertStringContainsString('Failed to create migration:', $outputContent);
+    }
+}

--- a/tests/Unit/Command/MigrateCommandFactoryTest.php
+++ b/tests/Unit/Command/MigrateCommandFactoryTest.php
@@ -17,7 +17,7 @@ use Sirix\Cycle\Service\MigratorService;
 /**
  * @internal
  *
- * @coversNothing
+ * @covers \Sirix\Cycle\Command\Migrator\MigrateCommandFactory
  */
 class MigrateCommandFactoryTest extends TestCase
 {

--- a/tests/Unit/Command/RollbackCommandFactoryTest.php
+++ b/tests/Unit/Command/RollbackCommandFactoryTest.php
@@ -17,7 +17,7 @@ use Sirix\Cycle\Service\MigratorService;
 /**
  * @internal
  *
- * @coversNothing
+ * @covers \Sirix\Cycle\Command\Migrator\RollbackCommandFactory
  */
 class RollbackCommandFactoryTest extends TestCase
 {

--- a/tests/Unit/Service/MigratorServiceFactoryTest.php
+++ b/tests/Unit/Service/MigratorServiceFactoryTest.php
@@ -19,7 +19,7 @@ use TypeError;
 /**
  * @internal
  *
- * @coversNothing
+ * @covers \Sirix\Cycle\Service\MigratorServiceFactory
  */
 class MigratorServiceFactoryTest extends TestCase
 {

--- a/tests/Unit/Service/MigratorServiceTest.php
+++ b/tests/Unit/Service/MigratorServiceTest.php
@@ -18,7 +18,7 @@ use Throwable;
 /**
  * @internal
  *
- * @coversNothing
+ * @covers \Sirix\Cycle\Service\MigratorService
  */
 class MigratorServiceTest extends TestCase
 {


### PR DESCRIPTION
Introduces CreateMigrationCommand along with its factory and tests for creating migration files. Updates DI container config and composer dependencies, including Symfony Filesystem. Enhances test coverage with @covers annotations for existing tests.