### PR TITLE
Reorganize Cycle ORM configuration and add PSR-6 cache support 

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
   <img src="https://img.shields.io/packagist/dt/sirix/cycle-orm-factory?style=flat-square" alt="Total Installs">
 </a>
 
+[Migration Guide from v1 to v2](docs/v1-to-v2.md)
+
 This package provides factories for integrating Cycle ORM into the Mezzio framework, providing seamless setup and configuration.
 ### Installation
 ```bash
@@ -255,3 +257,47 @@ php vendor/bin/laminas migrator:create-migration PascalCaseMigrationName
 **Note**: Make sure that you have correctly configured the database connection and migrations settings in your project's configuration file.
 
 For more information about using migrations with Cycle ORM, see the [Cycle ORM Documentation](https://cycle-orm.dev/docs/database-migrations/current/en).
+
+### Cache Configuration Example
+
+You can create a Symfony Cache Filesystem Adapter for your application like this:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+use Symfony\Component\Cache\Adapter\FilesystemAdapter;
+
+return [
+    'dependencies' => [
+        'factories' => [
+            'Cache\Symfony\Filesystem' => function () {
+                // Create a Symfony Cache File Adapter instance
+                return new FilesystemAdapter(
+                    'cycle', // Namespace prefix for cache keys
+                    0, // Default TTL of items in seconds (0 means infinite)
+                    'data/cycle/cache' // Absolute or relative directory for cache files storage
+                );
+            },
+        ],
+    ],
+];
+```
+
+This configuration creates a Filesystem Cache Adapter with the following parameters:
+- `'cycle'`: A namespace prefix for cache keys, helping to avoid key collisions
+- `0`: Default Time-To-Live (TTL) set to infinite, meaning cached items won't expire automatically
+- `'data/cycle/cache'`: Directory where cache files will be stored
+
+    'cache' => [
+        'enabled' => true,
+        'key' => 'cycle_orm_cached_schema',
+        'service' => function () {
+            return new Symfony\Component\Cache\Adapter\FilesystemAdapter(
+                'cycle', // Namespace prefix for cache keys
+                0,      // Default TTL of items in seconds (0 means infinite)
+                'data/cycle/cache' // Directory for cache files storage
+            );
+        },
+    ],

--- a/README.md
+++ b/README.md
@@ -290,14 +290,13 @@ This configuration creates a Filesystem Cache Adapter with the following paramet
 - `0`: Default Time-To-Live (TTL) set to infinite, meaning cached items won't expire automatically
 - `'data/cycle/cache'`: Directory where cache files will be stored
 
+
+Then, you can configure the Cycle ORM Factory to use this cache service like this:
+```php
     'cache' => [
         'enabled' => true,
         'key' => 'cycle_orm_cached_schema',
-        'service' => function () {
-            return new Symfony\Component\Cache\Adapter\FilesystemAdapter(
-                'cycle', // Namespace prefix for cache keys
-                0,      // Default TTL of items in seconds (0 means infinite)
-                'data/cycle/cache' // Directory for cache files storage
-            );
+        'service' => 'Cache\Symfony\Filesystem'
         },
     ],
+```

--- a/README.md
+++ b/README.md
@@ -293,10 +293,12 @@ This configuration creates a Filesystem Cache Adapter with the following paramet
 
 Then, you can configure the Cycle ORM Factory to use this cache service like this:
 ```php
-    'cache' => [
-        'enabled' => true,
-        'key' => 'cycle_orm_cached_schema',
-        'service' => 'Cache\Symfony\Filesystem'
-        },
-    ],
+'schema' => [
+  'cache' => [
+      'enabled' => true,
+      'key' => 'cycle_orm_cached_schema',
+      'service' => 'Cache\Symfony\Filesystem'
+      ],
+  // Other schema configurations...   
+],
 ```

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
   <img src="https://img.shields.io/packagist/dt/sirix/cycle-orm-factory?style=flat-square" alt="Total Installs">
 </a>
 
-
+[Migration Guide: Cycle ORM Factory v1 to v2](docs/v1-to-v2.md)
 
 This package provides factories for integrating Cycle ORM into the Mezzio framework, providing seamless setup and configuration.
 ### Installation
@@ -54,7 +54,7 @@ return [
             'table' => 'migrations'
         ],
         'entities' => [
-            'src/App/src/Entity',
+            'src/App/src/Entity', // The 'entities' configuration must always be present and point to an existing directory, even when working with manual entities.
         ],
         'schema' => [
             'property' => SchemaProperty::GenerateMigrations,
@@ -166,6 +166,7 @@ return [
 ];
 ```
 See the [Cycle ORM documentation](https://cycle-orm.dev/docs/schema-manual/current/en) for more information on manual mapping schema definitions.
+
 
 
 ### Schema Configuration

--- a/README.md
+++ b/README.md
@@ -200,6 +200,9 @@ The GenerateMigrations option is used to automatically generate migration files 
 
 Select the appropriate SchemaProperty option based on the requirements of your project. Customize the configuration to your needs and enjoy the seamless integration of Cycle ORM with Mezzio.
 
+* Note: The schema properties (e.g., SyncTables, GenerateMigrations) work only with annotated entities.
+* Ensure that your entity classes are properly annotated to leverage these features.
+
 ### Use in your project
 ```php
 $container->get('orm'); // Cycle\ORM\ORM

--- a/README.md
+++ b/README.md
@@ -213,42 +213,42 @@ For more information about Cycle ORM, see the [Cycle ORM documentation](https://
 ## Migrator Commands
 The `Sirix\Cycle\Command\Migrator` namespace provides three commands for managing database migrations using Cycle ORM. These commands are intended for use with the `laminas-cli` tool.
 
-### 1. `migrator:migrate` Command
+### 1. `cycle:migrator:run` Command
 
 #### Description
-The `migrator:migrate` command performs the necessary database migration steps, applying changes specified in migration files to synchronize your database schema.
+The `cycle:migrator:run` command performs the necessary database migration steps, applying changes specified in migration files to synchronize your database schema.
 
 #### Usage
 ```bash
-php vendor/bin/laminas migrator:migrate
+php vendor/bin/laminas cycle:migrator:run
 ```
 
 #### Options
 This command has no additional options.
 
 
-### 2. `migrator:rollback` Command
+### 2. `cycle:migrator:rollback` Command
 
 #### Description
-The `migrator:rollback` command undoes the changes made by the last migration, reverting your database schema to its previous state.
+The `cycle:migrator:rollback` command undoes the changes made by the last migration, reverting your database schema to its previous state.
 
 #### Usage
 ```bash
-php vendor/bin/laminas migrator:rollback
+php vendor/bin/laminas cycle:migrator:rollback
 ```
 
 #### Options
 This command does not have any additional options.
 
 
-### 3. `migrator:create-migration` Command
+### 3. `cycle:migrator:generate` Command
 
 #### Description
-The `migrator:create-migration` command generates a new empty migration file in the migration directory.
+The `cycle:migrator:generate` command generates a new empty migration file in the migration directory.
 
 #### Usage
 ```bash
-php vendor/bin/laminas migrator:create-migration PascalCaseMigrationName
+php vendor/bin/laminas cycle:migrator:generate PascalCaseMigrationName
 ```
 
 #### Options

--- a/README.md
+++ b/README.md
@@ -260,7 +260,7 @@ php vendor/bin/laminas cycle:migrator:generate PascalCaseMigrationName
 For more information about using migrations with Cycle ORM, see the [Cycle ORM Documentation](https://cycle-orm.dev/docs/database-migrations/current/en).
 
 
-### 4. `cycle:schema:cache:clear` Command
+### 4. `cycle:cache:clear` Command
 
 #### Description
 
@@ -271,7 +271,7 @@ configurations have been made, and you want to ensure fresh schema generation.
 #### Usage
 
 ```bash
-php vendor/bin/laminas cycle:schema:cache:clear
+php vendor/bin/laminas cycle:cache:clear
 ```
 
 #### Options

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
   <img src="https://img.shields.io/packagist/dt/sirix/cycle-orm-factory?style=flat-square" alt="Total Installs">
 </a>
 
-[Migration Guide from v1 to v2](docs/v1-to-v2.md)
+
 
 This package provides factories for integrating Cycle ORM into the Mezzio framework, providing seamless setup and configuration.
 ### Installation
@@ -258,6 +258,26 @@ php vendor/bin/laminas migrator:create-migration PascalCaseMigrationName
 
 For more information about using migrations with Cycle ORM, see the [Cycle ORM Documentation](https://cycle-orm.dev/docs/database-migrations/current/en).
 
+
+### 4. `cycle:schema:cache:clear` Command
+
+#### Description
+
+The `cycle:schema:cache:clear` command clears the cached Cycle ORM schema configuration, forcing the ORM to
+regenerate it on the next application run. This can be useful during development when changes to entity definitions or
+configurations have been made, and you want to ensure fresh schema generation.
+
+#### Usage
+
+```bash
+php vendor/bin/laminas cycle:schema:cache:clear
+```
+
+#### Options
+
+This command does not have any additional options.
+
+
 ### Cache Configuration Example
 
 You can create a Symfony Cache Filesystem Adapter for your application like this:
@@ -291,14 +311,12 @@ This configuration creates a Filesystem Cache Adapter with the following paramet
 - `'data/cycle/cache'`: Directory where cache files will be stored
 
 
-Then, you can configure the Cycle ORM Factory to use this cache service like this:
+The cache configuration will look like this:
 ```php
-'schema' => [
-  'cache' => [
-      'enabled' => true,
-      'key' => 'cycle_orm_cached_schema',
-      'service' => 'Cache\Symfony\Filesystem'
-      ],
-  // Other schema configurations...   
-],
+    'cache' => [
+        'enabled' => true,
+        'key' => 'cycle_orm_cached_schema',
+        'service' => 'Cache\Symfony\Filesystem';
+        },
+    ],
 ```

--- a/composer.json
+++ b/composer.json
@@ -16,12 +16,11 @@
         "cycle/database": "^2.11",
         "cycle/entity-behavior": "^1.3",
         "cycle/entity-behavior-uuid": "^1.2",
-        "cycle/migrations": "^v4.2.5",
+        "cycle/migrations": "^4.2.5",
         "cycle/orm": "^2.9",
         "cycle/schema-migrations-generator": "^2.3",
-        "symfony/cache": "^6.3 || ^7.2",
-        "symfony/console": "^6.3 || ^7.2",
-        "symfony/filesystem": "^6.3 || ^7.2"
+        "laminas/laminas-cli": "^1.11.0",
+        "psr/cache": "~1.0.0 || ~2.0.0. || ~3.0.0"
     },
     "require-dev": {
         "ergebnis/composer-normalize": "^2.39",
@@ -30,7 +29,9 @@
         "phpstan/phpstan": "^1.10",
         "phpstan/phpstan-mockery": "^1.1",
         "phpunit/phpunit": "^10.5 || ^11.5",
-        "roave/security-advisories": "dev-master"
+        "roave/security-advisories": "dev-master",
+        "symfony/cache": "^6.3 || ^7.2",
+        "symfony/filesystem": "^6.3 || ^7.2"
     },
     "autoload": {
         "psr-4": {

--- a/config/autoload/cycle-orm.global.php.dist
+++ b/config/autoload/cycle-orm.global.php.dist
@@ -10,82 +10,84 @@ use Sirix\Cycle\Enum\SchemaProperty;
 
 return [
     'cycle' => [
-        'default' => 'default',
-        'databases' => [
-            'default' => [
-                'connection' => 'mysql',
+        'db-config' => [
+            'default' => 'default',
+            'databases' => [
+                'default' => [
+                    'connection' => 'mysql',
+                ],
+            ],
+            'connections' => [
+                'mysql' => new Config\MySQLDriverConfig(
+                    connection: new Config\MySQL\TcpConnectionConfig(
+                        database: 'cycle-orm',
+                        host: '127.0.0.1',
+                        port: 3306,
+                        user: 'cycle',
+                        password: 'password'
+                    ),
+                    reconnect: true,
+                    timezone: 'UTC',
+                    queryCache: true,
+                ),
             ],
         ],
-        'connections' => [
-            'mysql' => new Config\MySQLDriverConfig(
-                connection: new Config\MySQL\TcpConnectionConfig(
-                    database: 'cycle-orm',
-                    host: '127.0.0.1',
-                    port: 3306,
-                    user: 'cycle',
-                    password: 'password'
-                ),
-                reconnect: true,
-                timezone: 'UTC',
-                queryCache: true,
-            ),
+        'migrator' => [
+            'directory' => 'db/migrations',
+            'table' => 'migrations',
         ],
-    ],
-    'migrator' => [
-        'directory' => 'db/migrations',
-        'table' => 'migrations',
-    ],
-    'entities' => [
-        'src/App/src/Entity',
-    ],
-    'schema' => [
-        'property' => SchemaProperty::GenerateMigrations,
-        'cache' => true,
-        'directory' => 'data/cache',
-        'manual_entity_schema_definition' => [
-            'user' => [
-                SchemaInterface::ENTITY => User::class,
-                SchemaInterface::MAPPER => Mapper::class,
-                SchemaInterface::DATABASE => 'default',
-                SchemaInterface::TABLE => 'user',
-                SchemaInterface::PRIMARY_KEY => 'id',
-                SchemaInterface::COLUMNS => [
-                    'id' => 'id',
-                    'email' => 'email',
-                    'balance' => 'balance',
-                ],
-                SchemaInterface::TYPECAST => [
-                    'id' => 'int',
-                    'balance' => 'float',
-                ],
-                SchemaInterface::RELATIONS => [
-                    'profile' => [
-                        Relation::TYPE => Relation::HAS_ONE,
-                        Relation::TARGET => 'profile',
-                        Relation::SCHEMA => [
-                            Relation::CASCADE => true,
-                            Relation::INNER_KEY => 'id',
-                            Relation::OUTER_KEY => 'user_id',
+        'entities' => [
+            'src/App/src/Entity',
+        ],
+        'schema' => [
+            'property' => SchemaProperty::GenerateMigrations,
+            'cache' => true,
+            'directory' => 'data/cache',
+            'manual_entity_schema_definition' => [
+                'user' => [
+                    SchemaInterface::ENTITY => User::class,
+                    SchemaInterface::MAPPER => Mapper::class,
+                    SchemaInterface::DATABASE => 'default',
+                    SchemaInterface::TABLE => 'user',
+                    SchemaInterface::PRIMARY_KEY => 'id',
+                    SchemaInterface::COLUMNS => [
+                        'id' => 'id',
+                        'email' => 'email',
+                        'balance' => 'balance',
+                    ],
+                    SchemaInterface::TYPECAST => [
+                        'id' => 'int',
+                        'balance' => 'float',
+                    ],
+                    SchemaInterface::RELATIONS => [
+                        'profile' => [
+                            Relation::TYPE => Relation::HAS_ONE,
+                            Relation::TARGET => 'profile',
+                            Relation::SCHEMA => [
+                                Relation::CASCADE => true,
+                                Relation::INNER_KEY => 'id',
+                                Relation::OUTER_KEY => 'user_id',
+                            ],
                         ],
                     ],
                 ],
-            ],
-            'profile' => [
-                SchemaInterface::ENTITY => Profile::class,
-                SchemaInterface::MAPPER => Mapper::class,
-                SchemaInterface::DATABASE => 'default',
-                SchemaInterface::TABLE => 'profile',
-                SchemaInterface::PRIMARY_KEY => 'id',
-                SchemaInterface::COLUMNS => [
-                    'id' => 'id',
-                    'user_id' => 'user_id',
-                    'image' => 'image',
+                'profile' => [
+                    SchemaInterface::ENTITY => Profile::class,
+                    SchemaInterface::MAPPER => Mapper::class,
+                    SchemaInterface::DATABASE => 'default',
+                    SchemaInterface::TABLE => 'profile',
+                    SchemaInterface::PRIMARY_KEY => 'id',
+                    SchemaInterface::COLUMNS => [
+                        'id' => 'id',
+                        'user_id' => 'user_id',
+                        'image' => 'image',
+                    ],
+                    SchemaInterface::TYPECAST => [
+                        'id' => 'int',
+                        'user_id' => 'int',
+                    ],
+                    SchemaInterface::RELATIONS => [],
                 ],
-                SchemaInterface::TYPECAST => [
-                    'id' => 'int',
-                    'user_id' => 'int',
-                ],
-                SchemaInterface::RELATIONS => [],
             ],
         ],
     ],

--- a/docs/v1-to-v2.md
+++ b/docs/v1-to-v2.md
@@ -48,15 +48,17 @@ have been introduced. Here are the details:
 - Old command names may no longer be valid in v2. Ensure you update any references to match their new names. You can
   find the updated commands in the Laminas CLI.
 
-##### Example Usage:
-
-To clear the schema cache, run the following command:
-
 ```shell
-php mezzio cycle:cache:clear
+./vendor/bin/laminas
 ```
 
-This command eliminates cached schema data, forcing the ORM to rebuild the schema on the next execution.
+```
+Command list:
+  cycle:cache:clear                       Clears the Cycle ORM schema cache
+  cycle:migrator:generate                 Create an empty migration file
+  cycle:migrator:rollback                 Rollback last migration
+  cycle:migrator:run                      Run migrations
+```
 
 ### Important Notes:
 

--- a/docs/v1-to-v2.md
+++ b/docs/v1-to-v2.md
@@ -10,7 +10,7 @@ compatibility with the new version. Here are the changes related to dependencies
 #### PSR-6 Cache Implementation
 
 Cycle ORM Factory v2 now requires a PSR-6 compliant cache implementation for schema caching. If your project does not
-already include one, consider adding a library such as `symfony/cache` or `cache/filesystem-adapter`.
+already include one, consider adding a library such as `symfony/cache`.
 
 - The configuration structure has been updated in v2. All configuration keys like `schema`, `migrator`, and `entities`
   are now grouped under the `cycle` key, and database configurations should be moved to

--- a/docs/v1-to-v2.md
+++ b/docs/v1-to-v2.md
@@ -38,6 +38,32 @@ introduced in Cycle ORM Factory v2.
 
 ## Key Changes in v2
 
+### Command Name Changes and New Command for Clearing Cache
+
+As part of the migration to Cycle ORM Factory v2, some command names have been updated for consistency, and new commands
+have been introduced. Here are the details:
+
+#### Updated Command Names
+
+- Old command names may no longer be valid in v2. Ensure you update any references to match their new names. You can
+  find the updated commands in the Laminas CLI.
+
+##### Example Usage:
+
+To clear the schema cache, run the following command:
+
+```shell
+php mezzio cycle:cache:clear
+```
+
+This command eliminates cached schema data, forcing the ORM to rebuild the schema on the next execution.
+
+### Important Notes:
+
+1. Clearing the schema cache is useful during development when schema updates are frequent.
+2. In production, consider clearing cache only when necessary, as clearing it forces a rebuild, which can cause a brief
+   performance overhead.
+
 ### Configuration Changes
 
 In Cycle ORM Factory v2, the configurations for `schema`, `migrator`, and `entities` have been moved under the `cycle` key. Additionally, database configurations have been relocated under `cycle => [ 'db-config' => [`.

--- a/docs/v1-to-v2.md
+++ b/docs/v1-to-v2.md
@@ -12,11 +12,6 @@ compatibility with the new version. Here are the changes related to dependencies
 Cycle ORM Factory v2 now requires a PSR-6 compliant cache implementation for schema caching. If your project does not
 already include one, consider adding a library such as `symfony/cache`.
 
-- The configuration structure has been updated in v2. All configuration keys like `schema`, `migrator`, and `entities`
-  are now grouped under the `cycle` key, and database configurations should be moved to
-  `cycle => [ 'db-config' => [ ... ]]`. This change ensures a more organized and centralized configuration structure.
-  Update your configuration files accordingly to prevent errors.
-
 To install `symfony/cache` for filesystem-based caching:
 
 ```shell

--- a/docs/v1-to-v2.md
+++ b/docs/v1-to-v2.md
@@ -1,0 +1,186 @@
+# Migration Guide: Cycle ORM Factory v1 to v2
+
+This guide will help you migrate your application from version 1.x to version 2.x of the Cycle ORM Factory for Mezzio.
+
+### Dependency Updates
+
+With the migration to Cycle ORM Factory v2, the dependencies in your application may need updates to ensure
+compatibility with the new version. Here are the changes related to dependencies:
+
+#### PSR-6 Cache Implementation
+
+Cycle ORM Factory v2 now requires a PSR-6 compliant cache implementation for schema caching. If your project does not
+already include one, consider adding a library such as `symfony/cache` or `cache/filesystem-adapter`.
+
+- The configuration structure has been updated in v2. All configuration keys like `schema`, `migrator`, and `entities`
+  are now grouped under the `cycle` key, and database configurations should be moved to
+  `cycle => [ 'db-config' => [ ... ]]`. This change ensures a more organized and centralized configuration structure.
+  Update your configuration files accordingly to prevent errors.
+
+To install `symfony/cache` for filesystem-based caching:
+
+```shell
+composer require symfony/cache
+```
+
+#### Updated Package Versions
+
+In addition to installing PSR-6 compatible cache packages, ensure that your application dependencies match the
+requirements of Cycle ORM Factory v2. Specifically, update the Cycle ORM Factory package as follows:
+
+```shell
+composer require sirix/cycle-orm-factory:^2.0
+```
+
+#### Laminas CLI Integration
+
+As part of the migration to Cycle ORM Factory v2, the `laminas/laminas-cli` package has been introduced as a dependency. This ensures better integration with Laminas-based applications and provides a consistent
+development experience.
+
+
+By updating dependencies, you ensure that your application is fully compatible with the new features and requirements
+introduced in Cycle ORM Factory v2.
+
+## Key Changes in v2
+
+### Configuration Changes
+
+In Cycle ORM Factory v2, the configurations for `schema`, `migrator`, and `entities` have been moved under the `cycle` key. Additionally, database configurations have been relocated under `cycle => [ 'db-config' => [`.
+
+#### Example:
+
+```php
+'cycle' => [
+    'db-config' => [
+        // Database configurations here...
+    ],
+    'schema' => [
+        // Schema configurations here...
+    ],
+    'migrator' => [
+        // Migrator configurations here...
+    ],
+    'entities' => [
+        // Entities configurations here...
+    ],
+],
+```
+
+### Cache Configuration
+
+The cache configuration has been updated in v2 to provide better flexibility and integration with PSR-compliant cache implementations.
+
+#### v1 Configuration (Old)
+
+```php
+'schema' => [
+    'cache' => true, // Simple boolean flag
+    // Other schema configurations...
+],
+```
+
+#### v2 Configuration (New)
+
+```php
+'cycle' => [
+    'schema' => [
+        'cache' => [
+            'enabled' => true,
+            'key' => 'cycle_cached_schema', // optional parameter
+            'service' => CacheItemPoolInterface::class, // optional parameter
+        ],
+        // Other schema configurations...
+    ],
+]
+```
+
+### Cache Service Integration
+
+In v2, you need to configure a cache service that implements `Psr\Cache\CacheItemPoolInterface`. Example using Symfony's Filesystem Adapter:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+use Psr\Cache\CacheItemPoolInterface;
+use Symfony\Component\Cache\Adapter\FilesystemAdapter;
+
+return [
+    'dependencies' => [
+        'factories' => [
+            CacheItemPoolInterface::class => function () {
+                return new FilesystemAdapter(
+                    'cycle', // Namespace prefix for cache keys
+                    0, // Default TTL of items in seconds (0 means infinite)
+                    'data/cycle/cache' // Cache directory
+                );
+            },
+        ],
+    ],
+];
+```
+
+### Disabling the Cache in v2
+
+If you wish to disable the cache in Cycle ORM Factory v2, you can set the `enabled` parameter in the `cache`
+configuration to `false`. This approach completely disables schema caching.
+
+#### Example Configuration
+
+```php
+'cycle' => [
+    'schema' => [
+        'cache' => [
+            'enabled' => false,
+        ],
+        // Other schema configurations...
+    ],
+]
+```
+
+### Important Notes
+
+- When caching is disabled, the ORM will rebuild the schema on every application execution, which may lead to
+  performance overhead.
+- This configuration is ideal for development environments where it is necessary to frequently update the schema or
+  debug schema-related issues.
+- In production environments, enabling caching is recommended for optimal performance.
+
+## Migration Steps
+
+1. **Update Package Version**
+
+   Update the package requirement in your `composer.json`:
+
+```shell script
+composer require sirix/cycle-orm-factory:^2.0
+```
+
+2. **Change Configuration Key Structure**
+
+   Update the configuration structure to match the new key hierarchy introduced in v2. Specifically, move database,
+   schema, migrator, and entity configurations under the `cycle` key for better organization and clarity.
+
+3. **Update Schema Cache Configuration**
+
+   Replace your simple boolean cache configuration with the new structured format.
+
+4. **Implement a Cache Service**
+
+   Create a service factory for a PSR-6 compliant cache implementation.
+
+
+## Breaking Changes
+
+- Configuration keys such as `schema`, `migrator`, and `entities` are now grouped under the `cycle` key, and all
+  database configurations have been moved under `cycle => [ 'db-config' => [ ... ]]`. Ensure you update your
+  configuration files to adhere to the new structure.
+- The `cache` configuration now requires a structured array instead of a simple boolean
+- Direct cache integration now requires a PSR-6 compliant cache service
+
+## Additional Notes
+
+- If you don't specify a custom `service` in the cache configuration, the factory will look for a service named `cache` that implements `CacheItemPoolInterface`
+- The default cache key has changed to `cycle_cached_schema` but can be customized
+

--- a/src/Command/Cycle/ClearCycleSchemaCache.php
+++ b/src/Command/Cycle/ClearCycleSchemaCache.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Sirix\Cycle\Command\Cycle;
 
 use Psr\Cache\CacheItemPoolInterface;
+use Sirix\Cycle\Enum\CommandName;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -23,7 +24,9 @@ final class ClearCycleSchemaCache extends Command
 
     protected function configure(): void
     {
-        $this->setDescription('Clears the Cycle ORM schema cache')
+        $this
+            ->setName(CommandName::ClearCache->value)
+            ->setDescription('Clears the Cycle ORM schema cache')
             ->setHelp('This command clears the cached schema for Cycle ORM')
         ;
     }

--- a/src/Command/Cycle/ClearCycleSchemaCache.php
+++ b/src/Command/Cycle/ClearCycleSchemaCache.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sirix\Cycle\Command\Cycle;
+
+use Psr\Cache\CacheItemPoolInterface;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Throwable;
+
+final class ClearCycleSchemaCache extends Command
+{
+    public function __construct(
+        private readonly CacheItemPoolInterface $cache,
+        private readonly string $cacheKey,
+        ?string $name = null
+    ) {
+        parent::__construct($name);
+    }
+
+    protected function configure(): void
+    {
+        $this->setDescription('Clears the Cycle ORM schema cache')
+            ->setHelp('This command clears the cached schema for Cycle ORM')
+        ;
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        try {
+            $deleted = $this->cache->deleteItem($this->cacheKey);
+
+            if ($deleted) {
+                $io->success('Cycle ORM schema cache has been cleared successfully.');
+            } else {
+                $io->note('No cache entry was found to clear.');
+            }
+
+            return Command::SUCCESS;
+        } catch (Throwable $e) {
+            $io->error('Failed to clear Cycle ORM schema cache: ' . $e->getMessage());
+
+            return Command::FAILURE;
+        }
+    }
+}

--- a/src/Command/Cycle/ClearCycleSchemaCacheFactory.php
+++ b/src/Command/Cycle/ClearCycleSchemaCacheFactory.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sirix\Cycle\Command\Cycle;
+
+use Psr\Container\ContainerExceptionInterface;
+use Psr\Container\ContainerInterface;
+use Psr\Container\NotFoundExceptionInterface;
+use Sirix\Cycle\Factory\CycleFactory;
+use Sirix\Cycle\Resolver\CacheAdapterResolver;
+use Symfony\Component\Console\Command\Command;
+
+class ClearCycleSchemaCacheFactory extends Command
+{
+    /**
+     * @throws ContainerExceptionInterface
+     * @throws NotFoundExceptionInterface
+     */
+    public function __invoke(ContainerInterface $container): ClearCycleSchemaCache
+    {
+        $config = $container->has('config') ? $container->get('config') : [];
+
+        $cacheKey = $config['cycle']['schema']['cache']['key'] ?? CycleFactory::DEFAULT_CACHE_KEY;
+
+        $cache = (new CacheAdapterResolver())->resolve($container, $config);
+
+        return new ClearCycleSchemaCache($cache, $cacheKey);
+    }
+}

--- a/src/Command/Migrator/CreateMigrationCommand.php
+++ b/src/Command/Migrator/CreateMigrationCommand.php
@@ -35,7 +35,7 @@ final class CreateMigrationCommand extends Command
 
     protected function configure(): void
     {
-        $this->setName(CommandName::GenerateMigrations->value)
+        $this->setName(CommandName::GenerateMigration->value)
             ->setDescription('Create an empty migration file')
             ->addArgument('migrationName', InputArgument::REQUIRED, 'The name of the migration in PascalCase format')
         ;

--- a/src/Command/Migrator/CreateMigrationCommand.php
+++ b/src/Command/Migrator/CreateMigrationCommand.php
@@ -22,7 +22,7 @@ use function random_bytes;
 use function sprintf;
 use function ucfirst;
 
-class CreateMigrationCommand extends Command
+final class CreateMigrationCommand extends Command
 {
     public function __construct(private readonly string $migrationDirectory, ?string $name = null)
     {

--- a/src/Command/Migrator/CreateMigrationCommand.php
+++ b/src/Command/Migrator/CreateMigrationCommand.php
@@ -4,15 +4,16 @@ declare(strict_types=1);
 
 namespace Sirix\Cycle\Command\Migrator;
 
-use Sirix\Cycle\Enum\CommandName;
 use const DIRECTORY_SEPARATOR;
 
 use DateTime;
 use Exception;
+use Sirix\Cycle\Enum\CommandName;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\Filesystem\Filesystem;
 
 use function bin2hex;
@@ -42,10 +43,12 @@ final class CreateMigrationCommand extends Command
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
+        $io = new SymfonyStyle($input, $output);
+
         $migrationName = $input->getArgument('migrationName');
 
         if (! preg_match('/^[A-Z][A-Za-z0-9]+$/', $migrationName)) {
-            $output->writeln('<error>Invalid migration name. Use PascalCase format.</error>');
+            $io->error('Invalid migration name. Use PascalCase format.');
 
             return Command::FAILURE;
         }
@@ -61,9 +64,9 @@ final class CreateMigrationCommand extends Command
 
         try {
             $filesystem->dumpFile($filePath, $fileContent);
-            $output->writeln("<info>Migration created: {$filePath}</info>");
+            $io->success("Migration created: {$filePath}");
         } catch (Exception $e) {
-            $output->writeln("<error>Failed to create migration: {$e->getMessage()}</error>");
+            $io->error("Failed to create migration: {$e->getMessage()}");
 
             return Command::FAILURE;
         }

--- a/src/Command/Migrator/CreateMigrationCommand.php
+++ b/src/Command/Migrator/CreateMigrationCommand.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Sirix\Cycle\Command\Migrator;
 
+use Sirix\Cycle\Enum\CommandName;
 use const DIRECTORY_SEPARATOR;
 
 use DateTime;
@@ -24,6 +25,8 @@ use function ucfirst;
 
 final class CreateMigrationCommand extends Command
 {
+    private const UNIQUE_ID_LENGTH = 18;
+
     public function __construct(private readonly string $migrationDirectory, ?string $name = null)
     {
         parent::__construct($name);
@@ -31,7 +34,7 @@ final class CreateMigrationCommand extends Command
 
     protected function configure(): void
     {
-        $this->setName('migrator:create-migration')
+        $this->setName(CommandName::GenerateMigrations->value)
             ->setDescription('Create an empty migration file')
             ->addArgument('migrationName', InputArgument::REQUIRED, 'The name of the migration in PascalCase format')
         ;
@@ -104,7 +107,7 @@ final class CreateMigrationCommand extends Command
     private function getUniqueId(): string
     {
         try {
-            return bin2hex(random_bytes(18));
+            return bin2hex(random_bytes(self::UNIQUE_ID_LENGTH));
         } catch (Exception) {
             return bin2hex(md5(microtime()));
         }

--- a/src/Command/Migrator/CreateMigrationCommandFactory.php
+++ b/src/Command/Migrator/CreateMigrationCommandFactory.php
@@ -21,11 +21,11 @@ class CreateMigrationCommandFactory
             ? $container->get('config')
             : [];
 
-        if (! isset($config['migrator']['directory'])) {
+        if (! isset($config['cycle']['migrator']['directory'])) {
             throw new ConfigException('Expected config migrator');
         }
 
-        $migrationDirectory = $config['migrator']['directory'];
+        $migrationDirectory = $config['cycle']['migrator']['directory'];
 
         return new CreateMigrationCommand($migrationDirectory);
     }

--- a/src/Command/Migrator/MigrateCommand.php
+++ b/src/Command/Migrator/MigrateCommand.php
@@ -22,7 +22,7 @@ final class MigrateCommand extends Command
     protected function configure(): void
     {
         $this
-            ->setName(CommandName::RunMigrations->value)
+            ->setName(CommandName::RunMigration->value)
             ->setDescription('Run migrations')
         ;
     }

--- a/src/Command/Migrator/MigrateCommand.php
+++ b/src/Command/Migrator/MigrateCommand.php
@@ -9,6 +9,8 @@ use Sirix\Cycle\Service\MigratorService;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Throwable;
 
 final class MigrateCommand extends Command
 {
@@ -27,7 +29,21 @@ final class MigrateCommand extends Command
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $this->migratorService->migrate();
+        $io = new SymfonyStyle($input, $output);
+
+        $io->section('Starting Migration Process');
+
+        try {
+            $this->migratorService->migrate(function(string $message) use ($io): void {
+                $io->writeln($message);
+            });
+        } catch (Throwable $exception) {
+            $io->error("An error occurred during migration: {$exception->getMessage()}");
+
+            return Command::FAILURE;
+        }
+
+        $io->success('Migration successful');
 
         return Command::SUCCESS;
     }

--- a/src/Command/Migrator/MigrateCommand.php
+++ b/src/Command/Migrator/MigrateCommand.php
@@ -9,7 +9,7 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class MigrateCommand extends Command
+final class MigrateCommand extends Command
 {
     public function __construct(private readonly MigratorService $migratorService, ?string $name = null)
     {

--- a/src/Command/Migrator/MigrateCommand.php
+++ b/src/Command/Migrator/MigrateCommand.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Sirix\Cycle\Command\Migrator;
 
+use Sirix\Cycle\Enum\CommandName;
 use Sirix\Cycle\Service\MigratorService;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
@@ -19,7 +20,7 @@ final class MigrateCommand extends Command
     protected function configure(): void
     {
         $this
-            ->setName('migrator:migrate')
+            ->setName(CommandName::RunMigrations->value)
             ->setDescription('Run migrations')
         ;
     }

--- a/src/Command/Migrator/RollbackCommand.php
+++ b/src/Command/Migrator/RollbackCommand.php
@@ -22,7 +22,7 @@ final class RollbackCommand extends Command
     protected function configure(): void
     {
         $this
-            ->setName(CommandName::RollbackMigrations->value)
+            ->setName(CommandName::RollbackMigration->value)
             ->setDescription('Rollback last migration')
         ;
     }

--- a/src/Command/Migrator/RollbackCommand.php
+++ b/src/Command/Migrator/RollbackCommand.php
@@ -9,6 +9,7 @@ use Sirix\Cycle\Service\MigratorService;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
 use Throwable;
 
 final class RollbackCommand extends Command
@@ -31,7 +32,17 @@ final class RollbackCommand extends Command
      */
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $this->migratorService->rollback();
+        $io = new SymfonyStyle($input, $output);
+
+        try {
+            $this->migratorService->rollback();
+        } catch (Throwable $e) {
+            $io->error($e->getMessage());
+
+            return Command::FAILURE;
+        }
+
+        $io->success('Migration rollback successful');
 
         return Command::SUCCESS;
     }

--- a/src/Command/Migrator/RollbackCommand.php
+++ b/src/Command/Migrator/RollbackCommand.php
@@ -10,7 +10,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Throwable;
 
-class RollbackCommand extends Command
+final class RollbackCommand extends Command
 {
     public function __construct(private readonly MigratorService $migratorService, ?string $name = null)
     {

--- a/src/Command/Migrator/RollbackCommand.php
+++ b/src/Command/Migrator/RollbackCommand.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Sirix\Cycle\Command\Migrator;
 
+use Sirix\Cycle\Enum\CommandName;
 use Sirix\Cycle\Service\MigratorService;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
@@ -20,7 +21,7 @@ final class RollbackCommand extends Command
     protected function configure(): void
     {
         $this
-            ->setName('migrator:rollback')
+            ->setName(CommandName::RollbackMigrations->value)
             ->setDescription('Rollback last migration')
         ;
     }

--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -51,7 +51,7 @@ class ConfigProvider
             'commands' => [
                 CommandName::RunMigrations->value => Command\Migrator\MigrateCommand::class,
                 CommandName::RollbackMigrations->value => Command\Migrator\RollbackCommand::class,
-                CommandName::GenerateMigrations->value => Command\Migrator\CreateMigrationCommand::class,
+                CommandName::GenerateMigration->value => Command\Migrator\CreateMigrationCommand::class,
                 CommandName::ClearCache->value => Command\Cycle\ClearCycleSchemaCache::class,
             ],
         ];

--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -49,8 +49,8 @@ class ConfigProvider
     {
         return [
             'commands' => [
-                CommandName::RunMigrations->value => Command\Migrator\MigrateCommand::class,
-                CommandName::RollbackMigrations->value => Command\Migrator\RollbackCommand::class,
+                CommandName::RunMigration->value => Command\Migrator\MigrateCommand::class,
+                CommandName::RollbackMigration->value => Command\Migrator\RollbackCommand::class,
                 CommandName::GenerateMigration->value => Command\Migrator\CreateMigrationCommand::class,
                 CommandName::ClearCache->value => Command\Cycle\ClearCycleSchemaCache::class,
             ],

--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -49,9 +49,9 @@ class ConfigProvider
     {
         return [
             'commands' => [
-                CommandName::GenerateMigrations->value => Command\Migrator\MigrateCommand::class,
+                CommandName::RunMigrations->value => Command\Migrator\MigrateCommand::class,
                 CommandName::RollbackMigrations->value => Command\Migrator\RollbackCommand::class,
-                CommandName::RunMigrations->value => Command\Migrator\CreateMigrationCommand::class,
+                CommandName::GenerateMigrations->value => Command\Migrator\CreateMigrationCommand::class,
                 CommandName::ClearCache->value => Command\Cycle\ClearCycleSchemaCache::class,
             ],
         ];

--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Sirix\Cycle;
 
+use Sirix\Cycle\Enum\CommandName;
 use Sirix\Cycle\Factory\CycleFactory;
 use Sirix\Cycle\Factory\DbalFactory;
 use Sirix\Cycle\Factory\MigratorFactory;
@@ -48,10 +49,10 @@ class ConfigProvider
     {
         return [
             'commands' => [
-                'migrator:migrate' => Command\Migrator\MigrateCommand::class,
-                'migrator:rollback' => Command\Migrator\RollbackCommand::class,
-                'migrator:create-migration' => Command\Migrator\CreateMigrationCommand::class,
-                'cycle:schema:cache:clear' => Command\Cycle\ClearCycleSchemaCache::class,
+                CommandName::GenerateMigrations->value => Command\Migrator\MigrateCommand::class,
+                CommandName::RollbackMigrations->value => Command\Migrator\RollbackCommand::class,
+                CommandName::RunMigrations->value => Command\Migrator\CreateMigrationCommand::class,
+                CommandName::ClearCache->value => Command\Cycle\ClearCycleSchemaCache::class,
             ],
         ];
     }

--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -36,6 +36,7 @@ class ConfigProvider
                 Command\Migrator\MigrateCommand::class => Command\Migrator\MigrateCommandFactory::class,
                 Command\Migrator\RollbackCommand::class => Command\Migrator\RollbackCommandFactory::class,
                 Command\Migrator\CreateMigrationCommand::class => Command\Migrator\CreateMigrationCommandFactory::class,
+                Command\Cycle\ClearCycleSchemaCache::class => Command\Cycle\ClearCycleSchemaCacheFactory::class,
             ],
         ];
     }
@@ -50,6 +51,7 @@ class ConfigProvider
                 'migrator:migrate' => Command\Migrator\MigrateCommand::class,
                 'migrator:rollback' => Command\Migrator\RollbackCommand::class,
                 'migrator:create-migration' => Command\Migrator\CreateMigrationCommand::class,
+                'cycle:schema:cache:clear' => Command\Cycle\ClearCycleSchemaCache::class,
             ],
         ];
     }

--- a/src/Enum/CommandName.php
+++ b/src/Enum/CommandName.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Sirix\Cycle\Enum;
+
+enum CommandName: string
+{
+    case GenerateMigrations = 'cycle:migrator:generate';
+    case RollbackMigrations = 'cycle:migrator:rollback';
+    case RunMigrations = 'cycle:migrator:run';
+    case ClearCache = 'cycle:cache:clear';
+}

--- a/src/Enum/CommandName.php
+++ b/src/Enum/CommandName.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Sirix\Cycle\Enum;
 
 enum CommandName: string

--- a/src/Enum/CommandName.php
+++ b/src/Enum/CommandName.php
@@ -6,7 +6,7 @@ namespace Sirix\Cycle\Enum;
 
 enum CommandName: string
 {
-    case GenerateMigrations = 'cycle:migrator:generate';
+    case GenerateMigration = 'cycle:migrator:generate';
     case RollbackMigrations = 'cycle:migrator:rollback';
     case RunMigrations = 'cycle:migrator:run';
     case ClearCache = 'cycle:cache:clear';

--- a/src/Enum/CommandName.php
+++ b/src/Enum/CommandName.php
@@ -7,7 +7,7 @@ namespace Sirix\Cycle\Enum;
 enum CommandName: string
 {
     case GenerateMigration = 'cycle:migrator:generate';
-    case RollbackMigrations = 'cycle:migrator:rollback';
-    case RunMigrations = 'cycle:migrator:run';
+    case RollbackMigration = 'cycle:migrator:rollback';
+    case RunMigration = 'cycle:migrator:run';
     case ClearCache = 'cycle:cache:clear';
 }

--- a/src/Factory/CycleFactory.php
+++ b/src/Factory/CycleFactory.php
@@ -171,7 +171,7 @@ class CycleFactory
     private function resolveCacheAdapter(ContainerInterface $container, array $config): CacheItemPoolInterface
     {
         if (isset($config['cycle']['schema']['cache']['service'])) {
-            $cacheService = $container->get($config['schema']['cache']['service']);
+            $cacheService = $container->get($config['cycle']['schema']['cache']['service']);
             if ($cacheService instanceof CacheItemPoolInterface) {
                 return $cacheService;
             }

--- a/src/Factory/DbalFactory.php
+++ b/src/Factory/DbalFactory.php
@@ -21,11 +21,11 @@ class DbalFactory
     {
         $config = $container->has('config') ? $container->get('config') : [];
 
-        if (! isset($config['cycle'])) {
+        if (! isset($config['cycle']['db-config'])) {
             throw new ConfigException('Expected config databases');
         }
 
-        $config = $config['cycle'];
+        $config = $config['cycle']['db-config'];
 
         return new DatabaseManager(new Config\DatabaseConfig($config));
     }

--- a/src/Factory/MigratorFactory.php
+++ b/src/Factory/MigratorFactory.php
@@ -22,11 +22,11 @@ class MigratorFactory
     {
         $config = $container->has('config') ? $container->get('config') : [];
 
-        if (! isset($config['migrator'])) {
+        if (! isset($config['cycle']['migrator'])) {
             throw new ConfigException('Expected config migrator');
         }
 
-        $config = $config['migrator'];
+        $config = $config['cycle']['migrator'];
 
         $migratorConfig = new Migrations\Config\MigrationConfig($config);
 

--- a/src/Resolver/CacheAdapterResolver.php
+++ b/src/Resolver/CacheAdapterResolver.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sirix\Cycle\Resolver;
+
+use Cycle\ORM\Exception\ConfigException;
+use Psr\Cache\CacheItemPoolInterface;
+use Psr\Container\ContainerExceptionInterface;
+use Psr\Container\ContainerInterface;
+use Psr\Container\NotFoundExceptionInterface;
+
+use function sprintf;
+
+class CacheAdapterResolver
+{
+    /**
+     * Resolves cache adapter from container or configuration.
+     *
+     * @param array<string, mixed> $config
+     *
+     * @throws ConfigException
+     * @throws ContainerExceptionInterface
+     * @throws NotFoundExceptionInterface
+     */
+    public function resolve(ContainerInterface $container, array $config): CacheItemPoolInterface
+    {
+        if (isset($config['cycle']['schema']['cache']['service'])) {
+            $cacheService = $container->get($config['cycle']['schema']['cache']['service']);
+            if ($cacheService instanceof CacheItemPoolInterface) {
+                return $cacheService;
+            }
+
+            throw new ConfigException(
+                sprintf(
+                    'Cache service "%s" must implement Psr\Cache\CacheItemPoolInterface',
+                    $config['cycle']['schema']['cache']['service']
+                )
+            );
+        }
+
+        if ($container->has('cache')) {
+            $cache = $container->get('cache');
+            if ($cache instanceof CacheItemPoolInterface) {
+                return $cache;
+            }
+
+            throw new ConfigException('Cache service must implement Psr\Cache\CacheItemPoolInterface');
+        }
+
+        throw new ConfigException(
+            'No PSR-6 cache implementation found. Please configure a cache service '
+            . 'that implements Psr\Cache\CacheItemPoolInterface'
+        );
+    }
+}

--- a/src/Service/MigratorService.php
+++ b/src/Service/MigratorService.php
@@ -12,18 +12,28 @@ class MigratorService
 {
     public function __construct(private readonly MigratorInterface $migrator) {}
 
-    public function migrate(): void
+    public function migrate(callable $output): void
     {
         if (! $this->migrator->isConfigured()) {
             $this->migrator->configure();
         }
 
         while (($migration = $this->migrator->run()) !== null) {
-            echo 'Migrating ' . $migration->getState()->getName() . PHP_EOL;
+            $output('Migrating ' . $migration->getState()->getName());
         }
-
-        echo 'Migrate successful' . PHP_EOL;
     }
+    //    public function migrate(): void
+    //    {
+    //        if (! $this->migrator->isConfigured()) {
+    //            $this->migrator->configure();
+    //        }
+    //
+    //        while (($migration = $this->migrator->run()) !== null) {
+    //            echo 'Migrating ' . $migration->getState()->getName() . PHP_EOL;
+    //        }
+    //
+    //        echo 'Migrate successful' . PHP_EOL;
+    //    }
 
     /**
      * @throws Throwable
@@ -35,7 +45,5 @@ class MigratorService
         }
 
         $this->migrator->rollback();
-
-        echo 'Rollback successful' . PHP_EOL;
     }
 }

--- a/test/Command/Cycle/ClearCycleSchemaCacheTest.php
+++ b/test/Command/Cycle/ClearCycleSchemaCacheTest.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sirix\Cycle\Test\Command\Cycle;
+
+use PHPUnit\Framework\MockObject\Exception;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Cache\CacheItemPoolInterface;
+use RuntimeException;
+use Sirix\Cycle\Command\Cycle\ClearCycleSchemaCache;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Exception\ExceptionInterface;
+use Symfony\Component\Console\Tester\CommandTester;
+
+class ClearCycleSchemaCacheTest extends TestCase
+{
+    private CacheItemPoolInterface|MockObject $cache;
+    private ClearCycleSchemaCache $command;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->cache = $this->createMock(CacheItemPoolInterface::class);
+        $this->command = new ClearCycleSchemaCache($this->cache, 'cache_key');
+    }
+
+    /**
+     * @throws Exception
+     * @throws ExceptionInterface
+     */
+    public function testExecuteCacheClearedSuccessfully(): void
+    {
+        $this->cache->expects($this->once())
+            ->method('deleteItem')
+            ->with('cache_key')
+            ->willReturn(true)
+        ;
+
+        $commandTester = new CommandTester($this->command);
+        $commandTester->execute([]);
+
+        $commandTester->assertCommandIsSuccessful();
+
+        $output = $commandTester->getDisplay();
+        $this->assertStringContainsString('[OK] Cycle ORM schema cache has been cleared successfully.', $output);
+    }
+
+    /**
+     * @throws ExceptionInterface
+     * @throws Exception
+     */
+    public function testExecuteCacheEntryNotFound(): void
+    {
+        $this->cache->expects($this->once())
+            ->method('deleteItem')
+            ->with('cache_key')
+            ->willReturn(false)
+        ;
+
+        $commandTester = new CommandTester($this->command);
+        $commandTester->execute([]);
+
+        $commandTester->assertCommandIsSuccessful();
+
+        $output = $commandTester->getDisplay();
+        $this->assertStringContainsString('[NOTE] No cache entry was found to clear.', $output);
+    }
+
+    /**
+     * @throws Exception
+     * @throws ExceptionInterface
+     */
+    public function testExecuteCacheClearingFails(): void
+    {
+        $this->cache->expects($this->once())
+            ->method('deleteItem')
+            ->with('cache_key')
+            ->willThrowException(new RuntimeException('Unexpected error'))
+        ;
+
+        $commandTester = new CommandTester($this->command);
+        $commandTester->execute([]);
+
+        $output = $commandTester->getDisplay();
+        $this->assertStringContainsString('[ERROR] Failed to clear Cycle ORM schema cache: Unexpected error', $output);
+        $this->AssertSame(Command::FAILURE, $commandTester->getStatusCode());
+    }
+}

--- a/test/Factory/DbalFactoryTest.php
+++ b/test/Factory/DbalFactoryTest.php
@@ -64,7 +64,13 @@ class DbalFactoryTest extends TestCase
             ->expects($this->once())
             ->method('get')
             ->with('config')
-            ->willReturn(['cycle' => []])
+            ->willReturn(
+                [
+                    'cycle' => [
+                        'db-config' => [],
+                    ],
+                ]
+            )
         ;
 
         $factory = new DbalFactory();

--- a/test/Factory/MigratorFactoryTest.php
+++ b/test/Factory/MigratorFactoryTest.php
@@ -20,7 +20,7 @@ class MigratorFactoryTest extends TestCase
 {
     private ContainerInterface|MockObject $container;
 
-    /** @var array<string, array<string, string>> */
+    /** @var array<string, mixed> */
     private array $config;
 
     /**
@@ -33,9 +33,11 @@ class MigratorFactoryTest extends TestCase
             ContainerInterface::class
         );
         $this->config = [
-            'migrator' => [
-                'directory' => 'db/migrations',
-                'table' => 'migrations',
+            'cycle' => [
+                'migrator' => [
+                    'directory' => 'db/migrations',
+                    'table' => 'migrations',
+                ],
             ],
         ];
     }

--- a/test/Resolver/CacheAdapterResolverTest.php
+++ b/test/Resolver/CacheAdapterResolverTest.php
@@ -1,0 +1,172 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sirix\Cycle\Test\Resolver;
+
+use Cycle\ORM\Exception\ConfigException;
+use PHPUnit\Framework\MockObject\Exception;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Cache\CacheItemPoolInterface;
+use Psr\Container\ContainerExceptionInterface;
+use Psr\Container\ContainerInterface;
+use Psr\Container\NotFoundExceptionInterface;
+use Sirix\Cycle\Resolver\CacheAdapterResolver;
+use stdClass;
+
+class CacheAdapterResolverTest extends TestCase
+{
+    private ContainerInterface|MockObject $container;
+    private CacheItemPoolInterface|MockObject $cacheService;
+
+    /**
+     * @throws Exception
+     */
+    public function setUp(): void
+    {
+        $this->container = $this->createMock(ContainerInterface::class);
+        $this->cacheService = $this->createMock(CacheItemPoolInterface::class);
+    }
+
+    /**
+     * @throws ContainerExceptionInterface
+     * @throws NotFoundExceptionInterface
+     * @throws Exception
+     */
+    public function testResolveWithConfiguredCacheService(): void
+    {
+        $config = [
+            'cycle' => [
+                'schema' => [
+                    'cache' => [
+                        'service' => 'custom_cache_service',
+                    ],
+                ],
+            ],
+        ];
+
+        $this->container
+            ->expects($this->once())
+            ->method('get')
+            ->with('custom_cache_service')
+            ->willReturn($this->cacheService)
+        ;
+
+        $resolver = new CacheAdapterResolver();
+        $resolvedCache = $resolver->resolve($this->container, $config);
+
+        $this->assertSame($this->cacheService, $resolvedCache);
+    }
+
+    /**
+     * @throws ContainerExceptionInterface
+     * @throws NotFoundExceptionInterface
+     * @throws Exception
+     */
+    public function testResolveWithInvalidConfiguredCacheService(): void
+    {
+        $this->expectException(ConfigException::class);
+        $this->expectExceptionMessage('must implement Psr\Cache\CacheItemPoolInterface');
+
+        $config = [
+            'cycle' => [
+                'schema' => [
+                    'cache' => [
+                        'service' => 'invalid_cache_service',
+                    ],
+                ],
+            ],
+        ];
+
+        $this->container
+            ->expects($this->once())
+            ->method('get')
+            ->with('invalid_cache_service')
+            ->willReturn(new stdClass())
+        ;
+
+        $resolver = new CacheAdapterResolver();
+        $resolver->resolve($this->container, $config);
+    }
+
+    /**
+     * @throws ContainerExceptionInterface
+     * @throws NotFoundExceptionInterface
+     * @throws Exception
+     */
+    public function testResolveWithDefaultCacheService(): void
+    {
+        $config = [];
+
+        $this->container
+            ->expects($this->once())
+            ->method('has')
+            ->with('cache')
+            ->willReturn(true)
+        ;
+        $this->container
+            ->expects($this->once())
+            ->method('get')
+            ->with('cache')
+            ->willReturn($this->cacheService)
+        ;
+
+        $resolver = new CacheAdapterResolver();
+        $resolvedCache = $resolver->resolve($this->container, $config);
+
+        $this->assertSame($this->cacheService, $resolvedCache);
+    }
+
+    /**
+     * @throws ContainerExceptionInterface
+     * @throws NotFoundExceptionInterface
+     * @throws Exception
+     */
+    public function testResolveWithInvalidDefaultCacheService(): void
+    {
+        $this->expectException(ConfigException::class);
+        $this->expectExceptionMessage('Cache service must implement Psr\Cache\CacheItemPoolInterface');
+
+        $config = [];
+
+        $this->container
+            ->expects($this->once())
+            ->method('has')
+            ->with('cache')
+            ->willReturn(true)
+        ;
+        $this->container
+            ->expects($this->once())
+            ->method('get')
+            ->with('cache')
+            ->willReturn(new stdClass())
+        ;
+
+        $resolver = new CacheAdapterResolver();
+        $resolver->resolve($this->container, $config);
+    }
+
+    /**
+     * @throws ContainerExceptionInterface
+     * @throws NotFoundExceptionInterface
+     * @throws Exception
+     */
+    public function testResolveThrowsExceptionWhenNoCacheServiceConfigured(): void
+    {
+        $this->expectException(ConfigException::class);
+        $this->expectExceptionMessage('No PSR-6 cache implementation found');
+
+        $config = [];
+
+        $this->container
+            ->expects($this->once())
+            ->method('has')
+            ->with('cache')
+            ->willReturn(false)
+        ;
+
+        $resolver = new CacheAdapterResolver();
+        $resolver->resolve($this->container, $config);
+    }
+}

--- a/test/Service/MigratorServiceTest.php
+++ b/test/Service/MigratorServiceTest.php
@@ -13,7 +13,6 @@ use Mockery\MockInterface;
 use PHPUnit\Framework\TestCase;
 use Sirix\Cycle\Service\MigratorInterface;
 use Sirix\Cycle\Service\MigratorService;
-use Throwable;
 
 class MigratorServiceTest extends TestCase
 {
@@ -69,26 +68,9 @@ class MigratorServiceTest extends TestCase
             )
         ;
 
-        $this->expectOutputString(
-            'Migrating tests-migration' . PHP_EOL
-            . 'Migrate successful' . PHP_EOL
-        );
-        $this->migratorService->migrate();
-    }
-
-    /**
-     * @throws Throwable
-     */
-    public function testRollback(): void
-    {
-        $this->migratorMock
-            ->shouldReceive('rollback')
-            ->once()
-        ;
-
-        $this->expectOutputString(
-            'Rollback successful' . PHP_EOL
-        );
-        $this->migratorService->rollback();
+        $this->expectOutputString('Migrating tests-migration' . PHP_EOL);
+        $this->migratorService->migrate(function($message) {
+            echo $message . PHP_EOL;
+        });
     }
 }


### PR DESCRIPTION
Reorganized Cycle ORM configuration structure for improved clarity and introduced support for PSR-6 caching for schema management. Updated factories and tests to align with the new configuration layout and cache integration. Dependencies have been adjusted to include PSR/cache and Laminas CLI.