### PR TITLE
feat: Reorganize dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.4.0] - 22/09/2025
+
+### Changed
+- Removed direct dependency on laminas-cli, moved it to suggest section
+- Added symfony/console as a direct dependency for command implementation
+- Updated README.md to show both symfony/console (direct) and laminas-cli (optional) command usage examples
+
 ## [2.3.1] - 30/08/2025
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ These factories provide the necessary parts to work seamlessly with Cycle ORM wi
 For more information about Cycle ORM, see the [Cycle ORM documentation](https://cycle-orm.dev/docs).
 
 ## Migrator Commands
-The `Sirix\Cycle\Command\Migrator` namespace provides some commands for managing database migrations and the cached Cycle ORM schema. These commands are intended for use with the `laminas-cli` tool.
+The `Sirix\Cycle\Command\Migrator` namespace provides some commands for managing database migrations and the cached Cycle ORM schema. These commands are built with symfony/console and can be used directly (note that direct usage of Symfony Console requires manual registration of commands). For Laminas/Mezzio applications, you can optionally integrate with `laminas-cli` by installing it as an additional package, which automatically registers all commands.
 
 ### 1. `cycle:migrator:run` Command
 
@@ -235,7 +235,10 @@ The `cycle:migrator:run` command performs the necessary database migration steps
 
 #### Usage
 ```bash
-# Run all pending migrations
+# With symfony/console (directly)
+php bin/console cycle:migrator:run
+
+# With laminas-cli (if installed as additional package)
 php vendor/bin/laminas cycle:migrator:run
 ```
 
@@ -250,6 +253,10 @@ The `cycle:migrator:rollback` command undoes the changes made by the last migrat
 
 #### Usage
 ```bash
+# With symfony/console (directly)
+php bin/console cycle:migrator:rollback
+
+# With laminas-cli (if installed as additional package)
 php vendor/bin/laminas cycle:migrator:rollback
 ```
 
@@ -264,6 +271,10 @@ The `cycle:migrator:create` command generates a new empty migration file in the 
 
 #### Usage
 ```bash
+# With symfony/console (directly)
+php bin/console cycle:migrator:create PascalCaseMigrationName
+
+# With laminas-cli (if installed as additional package)
 php vendor/bin/laminas cycle:migrator:create PascalCaseMigrationName
 ```
 
@@ -292,6 +303,10 @@ configurations have been made, and you want to ensure fresh schema generation.
 #### Usage
 
 ```bash
+# With symfony/console (directly)
+php bin/console cycle:cache:clear
+
+# With laminas-cli (if installed as additional package)
 php vendor/bin/laminas cycle:cache:clear
 ```
 
@@ -308,6 +323,10 @@ The `cycle:seed:create` command creates a new seed file in the seed directory. S
 #### Usage
 
 ```bash
+# With symfony/console (directly)
+php bin/console cycle:seed:create SeedName
+
+# With laminas-cli (if installed as additional package)
 php vendor/bin/laminas cycle:seed:create SeedName
 ```
 
@@ -327,6 +346,18 @@ The `cycle:seed:run` command executes seed files, populating your database with 
 #### Usage
 
 ```bash
+# With symfony/console (directly)
+# Run a specific seed
+php bin/console cycle:seed:run SeedName
+
+# Alternative ways to specify the seed
+php bin/console cycle:seed:run --seed SeedName
+php bin/console cycle:seed:run -s SeedName
+
+# Run all seeds in the configured directory
+php bin/console cycle:seed:run
+
+# With laminas-cli (if installed as additional package)
 # Run a specific seed
 php vendor/bin/laminas cycle:seed:run SeedName
 

--- a/composer.json
+++ b/composer.json
@@ -19,8 +19,8 @@
         "cycle/migrations": "^4.2.5",
         "cycle/orm": "^2.9",
         "cycle/schema-migrations-generator": "^2.3",
-        "laminas/laminas-cli": "^1.11.0",
         "psr/cache": "~1.0.0 || ~2.0.0. || ~3.0.0",
+        "symfony/console": "^6.4 || ^7.3",
         "symfony/filesystem": "^6.3 || ^7.2"
     },
     "require-dev": {
@@ -32,6 +32,9 @@
         "phpunit/phpunit": "^10.5 || ^11.5",
         "roave/security-advisories": "dev-master",
         "symfony/cache": "^6.3 || ^7.2"
+    },
+    "suggest": {
+        "laminas/laminas-cli": "Provides convenient CLI integration for Laminas/Mezzio applications"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
- Replace `laminas-cli` as a direct dependency with `symfony/console`
- Make `laminas-cli` optional and move it to suggest section in composer.json
- Update README examples to include `symfony/console` usage alongside `laminas-cli`
- Update CHANGELOG for version 2.4.0 with the above changes